### PR TITLE
Close Issue 19

### DIFF
--- a/High Precision Time Stamps.csproj
+++ b/High Precision Time Stamps.csproj
@@ -9,7 +9,7 @@
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <Authors>Christopher P. Susie</Authors>
     <Company>CJM Screws, LLC</Company>
-    <Version>1.0.0.1</Version>
+    <Version>1.0.0.2</Version>
     <Description>It is well known that DateTime.Now is often used inappropriately.  For example, it may be used together with TimeSpan to produce a task's timeout point or subtracted from another DateTime to calculate a duration.  This can cause subtle bugs because DateTime is not monotonic: the system clock can change, making the result of the subtraction inaccurate -- potentially causing a premature timeout or an infinite loop.  Yet, DateTime is an incredibly convenient and widely used value type in .NET code and is especially useful when printed in ISO-8601 format (with the "O" format specifier).  
 
 With the "O" specifier, you can resolution down to tenths of a microsecond, which is nice.  Until you learn that the resolution of the system clock is usually more coarse than several *milliseconds*, making the additional decimal places misleading garbage values. For calculating durations (time between events), it is better to use a high-resolution and monotonic clock like that provided by System.Diagnostics.Stopwatch: on most computers it is far more **accurate** than DateTime.Now even though, seemingly paradoxically, on a few systems, its *resolution* is lower than that of DateTime.  Also, unsurprisingly, Stopwatch does not provide values that correlate to times of day: while it is appropriate for calculating durations, it is inappropriate for timestamping against a readable date and time.  
@@ -17,23 +17,28 @@ With the "O" specifier, you can resolution down to tenths of a microsecond, whic
 This library provides timestamps (both as DateTime and as analogous value types it defines) that use the Stopwatch (and your system's high peformance event counter) as its clock, but returns values as DateTimes or an analog thereto so that these values can be used for a mixed purpose of timestamping and providing a meaningful way to calculate time elapsed between events or to calculate how long to perform a programmatic task.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReleaseNotes>
-      Release version 1.0.0.1
-      This release contains no changes to the code itself or to program behavior.  Instead it merely fixes the repository url to refer to the source repository rather than the http page that hosts the Github repository.  Also, it enables the nuget package to be built deterministically.
-      Release version 1.0
-      This is the non-beta release of the fix introduced with beta version 0.1.1.0-beta.  The issues resolved by that release included problems with serialization and deserialization of portable monotonic stamps when serialized on a system with a different DateTime.MinValue.ToUniversalTime() value than the one on which it is deserialized.  Those changes are discussed in pull request 14 [1], issue 12 [2] and issue 13 [3].  The changes to the code can be reviewed in pull request 14 [1], commit x [5] and, most particularly around these lines of code [6].
+      #### Version 1.0.0.2:
+      This release fixes a bug (see [Issue 19][1]) where the PortableDuration type's FromDays factory methods (and perhaps other From factory methods taking a double as a parameter) used incorrect math and incorrect validation logic.
 
-      [1]: https://github.com/cpsusie/High-Precision-Time-Stamps/pull/14
-      [2]: https://github.com/cpsusie/High-Precision-Time-Stamps/issues/12
-      [3]: https://github.com/cpsusie/High-Precision-Time-Stamps/issues/13
-      [4]: https://github.com/cpsusie/High-Precision-Time-Stamps/pull/14
-      [5]: https://github.com/cpsusie/High-Precision-Time-Stamps/commit/01670d88755a4775100f7dd9d09eef61e0775555
-      [6]: https://github.com/cpsusie/High-Precision-Time-Stamps/blob/01670d88755a4775100f7dd9d09eef61e0775555/PortableMonotonicStamp.cs#L540
+      #### Version 1.0.0.1:
+      This release contains no changes to the code itself or to program behavior.  Instead it merely fixes the repository url to refer to the source repository rather than the http page that hosts the Github repository.  Also, it enables the nuget package to be built deterministically.
+
+      #### Version 1.0.0.0:
+      This is the non-beta release of the fix introduced with beta version 0.1.1.0-beta.  The issues resolved by that release included problems with serialization and deserialization of portable monotonic stamps when serialized on a system with a different DateTime.MinValue.ToUniversalTime() value than the one on which it is deserialized.  Those changes are discussed in [pull request 14][2], [issue 12][3] and [issue 13][4].  The changes to the code can be reviewed in [pull request 14][2], [commit x][6] and, most particularly around [these lines of code][7].
+
+      [1]: https://github.com/cpsusie/High-Precision-Time-Stamps/issues/19
+      [2]: https://github.com/cpsusie/High-Precision-Time-Stamps/pull/14
+      [3]: https://github.com/cpsusie/High-Precision-Time-Stamps/issues/12
+      [4]: https://github.com/cpsusie/High-Precision-Time-Stamps/issues/13
+      [5]: https://github.com/cpsusie/High-Precision-Time-Stamps/pull/14
+      [6]: https://github.com/cpsusie/High-Precision-Time-Stamps/commit/01670d88755a4775100f7dd9d09eef61e0775555
+      [7]: https://github.com/cpsusie/High-Precision-Time-Stamps/blob/01670d88755a4775100f7dd9d09eef61e0775555/PortableMonotonicStamp.cs#L540
     </PackageReleaseNotes>
     <RepositoryUrl>https://github.com/cpsusie/High-Precision-Time-Stamps.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Timestamps DateTime Duration Monotonic-Clock TimeSpan High-Resolution ISO-8601</PackageTags>
-    <AssemblyVersion>1.0.0.1</AssemblyVersion>
-    <FileVersion>1.0.0.1</FileVersion>
+    <AssemblyVersion>1.0.0.2</AssemblyVersion>
+    <FileVersion>1.0.0.2</FileVersion>
     <Copyright>Copyright (c) 2020-2021 CJM Screws, LLC</Copyright>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/HighPrecisionTimeStamps.xml
+++ b/HighPrecisionTimeStamps.xml
@@ -3429,6 +3429,62 @@
             <returns>True if <paramref name="other"/> is a not null and is of type <see cref="T:HpTimeStamps.TimeStampUtil"/>,
             false otherwise.</returns>
         </member>
+        <member name="T:HpTimeStamps.UndefinedEnumArgumentException`1">
+            <summary>
+            An exception raised to indicate that the value of an argument of type <typeparamref name="TEnum"/> was
+            not a valued defined by the <typeparamref name="TEnum"/> enumeration type.
+            </summary>
+            <typeparam name="TEnum">A concrete (i.e. not <see cref="T:System.Enum"/> or <see cref="T:System.ValueType"/> or <see cref="T:System.Object"/>, but an actual specific)
+            enumeration type</typeparam>
+        </member>
+        <member name="P:HpTimeStamps.UndefinedEnumArgumentException`1.UndefinedValue">
+            <summary>
+            The undefined enum value
+            </summary>
+        </member>
+        <member name="P:HpTimeStamps.UndefinedEnumArgumentException`1.ParamName">
+            <summary>
+            The name of the parameter if known.  Empty string otherwise.
+            </summary>
+        </member>
+        <member name="M:HpTimeStamps.UndefinedEnumArgumentException`1.#ctor(`0)">
+            <summary>
+            CTOR
+            </summary>
+            <param name="undefinedValue">undefined enum value</param>
+        </member>
+        <member name="M:HpTimeStamps.UndefinedEnumArgumentException`1.#ctor(`0,System.Exception)">
+            <summary>
+            Ctor
+            </summary>
+            <param name="undefinedValue">The undefined enumeration value argument.</param>
+            <param name="inner">Inner exception if any</param>
+        </member>
+        <member name="M:HpTimeStamps.UndefinedEnumArgumentException`1.#ctor(`0,System.String)">
+            <summary>
+            Ctor
+            </summary>
+            <param name="undefinedValue">The undefined enumeration value argument.</param>
+            <param name="parameterName">The name of the invalid argument parameter if known</param>
+        </member>
+        <member name="M:HpTimeStamps.UndefinedEnumArgumentException`1.#ctor(`0,System.String,System.Exception)">
+            <summary>
+            Ctor
+            </summary>
+            <param name="undefinedValue">The undefined enumeration value argument.</param>
+            <param name="parameterName">The name of the invalid argument parameter if known</param>
+            <param name="inner">inner exception if any</param>
+        </member>
+        <member name="M:HpTimeStamps.UndefinedEnumArgumentException`1.#ctor(System.String,`0,System.String,System.Exception)">
+            <summary>
+            CTOR for inheritors
+            </summary>
+            <param name="message">Desired message. MANDATORY</param>
+            <param name="undefinedValue">the undefined enum value.  MANDATORY</param>
+            <param name="parameterName">the parameter name. OPTIONAL</param>
+            <param name="inner">inner exception.  OPTIONAL</param>
+            <exception cref="T:System.ArgumentNullException"><paramref name="message"/> was null.</exception>
+        </member>
         <member name="T:HpTimeStamps.UnsupportedDateTimeRangeException">
              <summary>
              This exception is thrown to indicate that on the current system,

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,5 @@
 MIT License
-
-Copyright (c) 2020 CJM Screws, LLC
+HighPrecisionTimeStamps Copyright (c) 2020-2021 CJM Screws, LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/PortableDuration.cs
+++ b/PortableDuration.cs
@@ -740,13 +740,16 @@ namespace HpTimeStamps
             return IntervalFromDoubleTicks(ticks);
         }
 
-        private static PortableDuration IntervalFromDoubleTicks(double ticks) //todofixit fuck up here.
+        private static PortableDuration IntervalFromDoubleTicks(double ticks) 
         {
+            //bug 19 fix: remove useless comparison to long max and doubly useless forgetting to check for long min.  
+            //the rep here is in int128 nanoseconds ticks.  doesn't matter for portable duration purposes if 
+            //cannot fit in long.
+
             if ((ticks > (double)PdInt.MaxValue) || (ticks < (double)PdInt.MinValue) || double.IsNaN(ticks))
-                throw new OverflowException("Value cannot fit in a TimeSpan.");
-            if (ticks >= long.MaxValue)
-                return MaxValue;
-            return new PortableDuration((long)ticks);
+                throw new OverflowException("Value cannot fit in a PortableDuration.");
+            
+            return new PortableDuration((PdInt) ticks);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/PortableDuration.cs
+++ b/PortableDuration.cs
@@ -740,7 +740,7 @@ namespace HpTimeStamps
             return IntervalFromDoubleTicks(ticks);
         }
 
-        private static PortableDuration IntervalFromDoubleTicks(double ticks)
+        private static PortableDuration IntervalFromDoubleTicks(double ticks) //todofixit fuck up here.
         {
             if ((ticks > (double)PdInt.MaxValue) || (ticks < (double)PdInt.MinValue) || double.IsNaN(ticks))
                 throw new OverflowException("Value cannot fit in a TimeSpan.");

--- a/Readme.md
+++ b/Readme.md
@@ -7,13 +7,13 @@ It is well known that DateTime.Now is often used inappropriately.  For example, 
 
 With the "O" specifier, you can resolution down to tenths of a microsecond, which is nice.  Until you learn that the resolution of the system clock is usually more coarse than several *milliseconds*, making the additional decimal places misleading garbage values. For calculating durations (time between events), it is better to use a high-resolution and monotonic clock like that provided by System.Diagnostics.Stopwatch: on most computers it is far more **accurate** than DateTime.Now even though, seemingly paradoxically, on a few systems, its *resolution* is lower than that of DateTime.  Also, unsurprisingly, Stopwatch does not provide values that correlate to times of day: while it is appropriate for calculating durations, it is inappropriate for timestamping against a readable date and time.  
   
-This library provides timestamps (both as DateTime and as analogous value types it defines) that use the Stopwatch (and your system's high peformance event counter) as its clock, but returns values as DateTimes or an analog thereto so that these values can be used for a mixed purpose of timestamping and providing a meaningful way to calculate time elapsed between events.  
+This library provides timestamps (both as DateTime and as analogous value types it defines) that use the Stopwatch (and your system's high performance event counter) as its clock, but returns values as DateTimes or an analog thereto so that these values can be used for a mixed purpose of timestamping and providing a meaningful way to calculate time elapsed between events.  
 
 It provides **Monotonic** timestamps and **High Resolution** timestamps.  
   
 ### High Resolution Timestamps   
 
-These timestamps are expressed as DateTime values and are derived from Stopwatch.  They are calibrated (correlating a reference tick value of the Stopwatch to a reference time value of the system clock) on a **per thread** basis and have a calibration window that expires.  These are suitable for logging times (in a way meaningful to humans) and can be used to measure the time elapsed between events *on a single thread* within **one calibration window**.  A calibration window by default lasts for fifteen minutes.  Eventually, there will be drift between the system clock and the Stopwatch, making recalibration necessary.  Nevertheless, for the resolution provided by Stopwatch, fifteen minutes should be a sufficient period for the intended use-case of these timestamps.  Also, you can always manually trigger a calibration.  
+These timestamps are expressed as DateTime values and are derived from Stopwatch.  They are calibrated (correlating a reference tick value of the Stopwatch to a reference time value of the system clock) on a **per thread** basis and have a calibration window that expires.  These are suitable for logging times (in a way meaningful to humans) and can be used to measure the time elapsed between events *on a single thread* within **one calibration window**.  A calibration window by default lasts for fifteen minutes.  Eventually, there will be drift between the system clock and the Stopwatch, making re-calibration necessary.  Nevertheless, for the resolution provided by Stopwatch, fifteen minutes should be a sufficient period for the intended use-case of these timestamps.  Also, you can always manually trigger a calibration.  
   
 ### Monotonic Timestamps  
   
@@ -458,16 +458,20 @@ I have used this library to good effect in many projects, even closed-source pro
 3. An Amazon Linux 2 (based on CentOS) system with a Stopwatch frequency of 1,000,000,000 ticks per second.
 4. An Amazon WorkSpaces Window Server (Windows 10 based Windows server) with (most vexingly) a stopwatch frequency of 2,441,366 ticks per second.  
 
-### Release Notes  
+### Release Notes
+#### Version 1.0.0.2:
+This release fixes a bug (see [Issue 19][1]) where the PortableDuration type's FromDays factory methods (and perhaps other From factory methods taking a double as a parameter) used incorrect math and incorrect validation logic.  
+
 #### Version 1.0.0.1:
 This release contains no changes to the code itself or to program behavior.  Instead it merely fixes the repository url to refer to the source repository rather than the http page that hosts the Github repository.  Also, it enables the nuget package to be built deterministically.
 
 #### Version 1.0.0.0:
-This is the non-beta release of the fix introduced with beta version 0.1.1.0-beta.  The issues resolved by that release included problems with serialization and deserialization of portable monotonic stamps when serialized on a system with a different DateTime.MinValue.ToUniversalTime() value than the one on which it is deserialized.  Those changes are discussed in [pull request 14][1], [issue 12][2] and [issue 13][3].  The changes to the code can be reviewed in [pull request 14][1], [commit x][5] and, most particularly around [these lines of code][6].
+This is the non-beta release of the fix introduced with beta version 0.1.1.0-beta.  The issues resolved by that release included problems with serialization and deserialization of portable monotonic stamps when serialized on a system with a different DateTime.MinValue.ToUniversalTime() value than the one on which it is deserialized.  Those changes are discussed in [pull request 14][2], [issue 12][3] and [issue 13][4].  The changes to the code can be reviewed in [pull request 14][2], [commit x][6] and, most particularly around [these lines of code][7].
 
-  [1]: https://github.com/cpsusie/High-Precision-Time-Stamps/pull/14
-  [2]: https://github.com/cpsusie/High-Precision-Time-Stamps/issues/12
-  [3]: https://github.com/cpsusie/High-Precision-Time-Stamps/issues/13
-  [4]: https://github.com/cpsusie/High-Precision-Time-Stamps/pull/14
-  [5]: https://github.com/cpsusie/High-Precision-Time-Stamps/commit/01670d88755a4775100f7dd9d09eef61e0775555
-  [6]: https://github.com/cpsusie/High-Precision-Time-Stamps/blob/01670d88755a4775100f7dd9d09eef61e0775555/PortableMonotonicStamp.cs#L540
+  [1]: https://github.com/cpsusie/High-Precision-Time-Stamps/issues/19
+  [2]: https://github.com/cpsusie/High-Precision-Time-Stamps/pull/14
+  [3]: https://github.com/cpsusie/High-Precision-Time-Stamps/issues/12
+  [4]: https://github.com/cpsusie/High-Precision-Time-Stamps/issues/13
+  [5]: https://github.com/cpsusie/High-Precision-Time-Stamps/pull/14
+  [6]: https://github.com/cpsusie/High-Precision-Time-Stamps/commit/01670d88755a4775100f7dd9d09eef61e0775555
+  [7]: https://github.com/cpsusie/High-Precision-Time-Stamps/blob/01670d88755a4775100f7dd9d09eef61e0775555/PortableMonotonicStamp.cs#L540

--- a/Release.txt
+++ b/Release.txt
@@ -1,11 +1,16 @@
-﻿Release version 1.0.0.1
-      This release contains no changes to the code itself or to program behavior.  Instead it merely fixes the repository url to refer to the source repository rather than the http page that hosts the Github repository.  Also, it enables the nuget package to be built deterministically.
-Release version 1.0
-      This is the non-beta release of the fix introduced with beta version 0.1.1.0-beta.  The issues resolved by that release included problems with serialization and deserialization of portable monotonic stamps when serialized on a system with a different DateTime.MinValue.ToUniversalTime() value than the one on which it is deserialized.  Those changes are discussed in pull request 14 [1], issue 12 [2] and issue 13 [3].  The changes to the code can be reviewed in pull request 14 [1], commit x [5] and, most particularly around these lines of code [6].
+﻿#### Version 1.0.0.2:
+This release fixes a bug (see [Issue 19][1]) where the PortableDuration type's FromDays factory methods (and perhaps other From factory methods taking a double as a parameter) used incorrect math and incorrect validation logic.  
 
-      [1]: https://github.com/cpsusie/High-Precision-Time-Stamps/pull/14
-      [2]: https://github.com/cpsusie/High-Precision-Time-Stamps/issues/12
-      [3]: https://github.com/cpsusie/High-Precision-Time-Stamps/issues/13
-      [4]: https://github.com/cpsusie/High-Precision-Time-Stamps/pull/14
-      [5]: https://github.com/cpsusie/High-Precision-Time-Stamps/commit/01670d88755a4775100f7dd9d09eef61e0775555
-      [6]: https://github.com/cpsusie/High-Precision-Time-Stamps/blob/01670d88755a4775100f7dd9d09eef61e0775555/PortableMonotonicStamp.cs#L540
+#### Version 1.0.0.1:
+This release contains no changes to the code itself or to program behavior.  Instead it merely fixes the repository url to refer to the source repository rather than the http page that hosts the Github repository.  Also, it enables the nuget package to be built deterministically.
+
+#### Version 1.0.0.0:
+This is the non-beta release of the fix introduced with beta version 0.1.1.0-beta.  The issues resolved by that release included problems with serialization and deserialization of portable monotonic stamps when serialized on a system with a different DateTime.MinValue.ToUniversalTime() value than the one on which it is deserialized.  Those changes are discussed in [pull request 14][2], [issue 12][3] and [issue 13][4].  The changes to the code can be reviewed in [pull request 14][2], [commit x][6] and, most particularly around [these lines of code][7].
+
+  [1]: https://github.com/cpsusie/High-Precision-Time-Stamps/issues/19
+  [2]: https://github.com/cpsusie/High-Precision-Time-Stamps/pull/14
+  [3]: https://github.com/cpsusie/High-Precision-Time-Stamps/issues/12
+  [4]: https://github.com/cpsusie/High-Precision-Time-Stamps/issues/13
+  [5]: https://github.com/cpsusie/High-Precision-Time-Stamps/pull/14
+  [6]: https://github.com/cpsusie/High-Precision-Time-Stamps/commit/01670d88755a4775100f7dd9d09eef61e0775555
+  [7]: https://github.com/cpsusie/High-Precision-Time-Stamps/blob/01670d88755a4775100f7dd9d09eef61e0775555/PortableMonotonicStamp.cs#L540

--- a/UndefinedEnumArgumentException.cs
+++ b/UndefinedEnumArgumentException.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using JetBrains.Annotations;
+
+namespace HpTimeStamps
+{
+    /// <summary>
+    /// An exception raised to indicate that the value of an argument of type <typeparamref name="TEnum"/> was
+    /// not a valued defined by the <typeparamref name="TEnum"/> enumeration type.
+    /// </summary>
+    /// <typeparam name="TEnum">A concrete (i.e. not <see cref="System.Enum"/> or <see cref="System.ValueType"/> or <see cref="System.Object"/>, but an actual specific)
+    /// enumeration type</typeparam>
+    public class UndefinedEnumArgumentException<TEnum> : ArgumentException where TEnum : unmanaged, Enum
+    {
+        /// <summary>
+        /// The undefined enum value
+        /// </summary>
+        public TEnum UndefinedValue { get; }
+
+        /// <summary>
+        /// The name of the parameter if known.  Empty string otherwise.
+        /// </summary>
+        [NotNull]
+        public sealed override string ParamName => _paramName ?? string.Empty;
+
+        /// <summary>
+        /// CTOR
+        /// </summary>
+        /// <param name="undefinedValue">undefined enum value</param>
+        public UndefinedEnumArgumentException(TEnum undefinedValue) : this(undefinedValue, null, null) {}
+
+        /// <summary>
+        /// Ctor
+        /// </summary>
+        /// <param name="undefinedValue">The undefined enumeration value argument.</param>
+        /// <param name="inner">Inner exception if any</param>
+        public UndefinedEnumArgumentException(TEnum undefinedValue, [CanBeNull] Exception inner) 
+            : this(undefinedValue, null, inner) { }
+
+        /// <summary>
+        /// Ctor
+        /// </summary>
+        /// <param name="undefinedValue">The undefined enumeration value argument.</param>
+        /// <param name="parameterName">The name of the invalid argument parameter if known</param>
+        public UndefinedEnumArgumentException(TEnum undefinedValue, [CanBeNull] string parameterName) 
+            : this(undefinedValue, parameterName, null) {}
+        
+
+        /// <summary>
+        /// Ctor
+        /// </summary>
+        /// <param name="undefinedValue">The undefined enumeration value argument.</param>
+        /// <param name="parameterName">The name of the invalid argument parameter if known</param>
+        /// <param name="inner">inner exception if any</param>
+        public UndefinedEnumArgumentException(TEnum undefinedValue, [CanBeNull] string parameterName,
+            [CanBeNull] Exception inner) : base(CreateMessage(undefinedValue, parameterName, inner), inner)
+        {
+            UndefinedValue = undefinedValue;
+            _paramName = parameterName ?? string.Empty;
+        }
+
+        /// <summary>
+        /// CTOR for inheritors
+        /// </summary>
+        /// <param name="message">Desired message. MANDATORY</param>
+        /// <param name="undefinedValue">the undefined enum value.  MANDATORY</param>
+        /// <param name="parameterName">the parameter name. OPTIONAL</param>
+        /// <param name="inner">inner exception.  OPTIONAL</param>
+        /// <exception cref="ArgumentNullException"><paramref name="message"/> was null.</exception>
+        protected UndefinedEnumArgumentException([NotNull] string message, TEnum undefinedValue,
+            [CanBeNull] string parameterName, [NotNull] Exception inner) : base(
+            message ?? throw new ArgumentNullException(nameof(message)), inner)
+        {
+            UndefinedValue = undefinedValue;
+            _paramName = parameterName ?? string.Empty;
+        }
+
+        [CanBeNull] private readonly string _paramName;
+
+        [NotNull]
+        static string CreateMessage(TEnum undefinedValue, [CanBeNull] string parameterName, [CanBeNull] Exception inner) =>
+            "The value of parameter " +
+            (!string.IsNullOrWhiteSpace(parameterName) ? parameterName + " " : string.Empty) +
+            $"(value: {undefinedValue.ToString()}) is not a defined value of the {nameof(TEnum)} enumeration type." +
+            (inner != null ? " Consult inner exception for details." : string.Empty);
+    }
+}

--- a/UnitTests/UnitTests/MonotonicStampTest.cs
+++ b/UnitTests/UnitTests/MonotonicStampTest.cs
@@ -244,6 +244,32 @@ namespace UnitTests
             Assert.True(diff <= 1000);
         }
 
+        [Fact]
+        public void TestPortableDurationFromDaysAccuracy()
+        {
+            int totalDays = -239805;
+            TimeSpan daysAsTs = TimeSpan.FromDays(totalDays);
+            PortableDuration fromTs = daysAsTs;
+            TimeSpan andBack = (TimeSpan)fromTs;
+            Assert.True(andBack == daysAsTs);
+            
+            Int128 ticksPerSecond = 1_000_000_000;
+            //start with minute, then hour, then day
+            Int128 ticksPerDay = ticksPerSecond * 60; //per minute
+            ticksPerDay *= 60; //per hour
+            ticksPerDay *= 24; //per day
+
+            Assert.True(PortableDuration.TicksPerDay == ticksPerDay);
+            Int128 totalDaysInNanoSeconds = totalDays * ticksPerDay;
+            Int128 totalDaysInNanoSecondsFromDouble = (Int128)(((double)totalDays) * ((double)(long)ticksPerDay));
+
+            PortableDuration fromInt = PortableDuration.FromDays(totalDays);
+            
+            
+            Assert.True(fromInt == fromTs);
+
+        }
+
         private IEnumerable<TimeSpan> GetNRandomTimespans(int numSpans)
         {
             if (numSpans < 0) throw new ArgumentOutOfRangeException(nameof(numSpans), numSpans, @"Value may not be negative.");


### PR DESCRIPTION
Closes Issue 19.  Primary culprit and resolution can be found [here.](https://github.com/cpsusie/High-Precision-Time-Stamps/compare/Issue_19?expand=1#diff-3381f168ec26ef9b611ab16ef099c0b41b063dc76395d893321c3e5303873998)  Unit tests added, version numbers and documentation updated to reflect.