### PR TITLE
Fix issue 21 and issue 22

### DIFF
--- a/ExampleCode/ExampleCode.csproj
+++ b/ExampleCode/ExampleCode.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <AssemblyName>ExampleTimestamps</AssemblyName>
     <RootNamespace>ExampleTimestamps</RootNamespace>
     <Authors>Christopher Susie</Authors>

--- a/High Precision Time Stamps.csproj
+++ b/High Precision Time Stamps.csproj
@@ -9,7 +9,7 @@
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <Authors>Christopher P. Susie</Authors>
     <Company>CJM Screws, LLC</Company>
-    <Version>1.0.0.2</Version>
+    <Version>1.0.0.4</Version>
     <Description>It is well known that DateTime.Now is often used inappropriately.  For example, it may be used together with TimeSpan to produce a task's timeout point or subtracted from another DateTime to calculate a duration.  This can cause subtle bugs because DateTime is not monotonic: the system clock can change, making the result of the subtraction inaccurate -- potentially causing a premature timeout or an infinite loop.  Yet, DateTime is an incredibly convenient and widely used value type in .NET code and is especially useful when printed in ISO-8601 format (with the "O" format specifier).  
 
 With the "O" specifier, you can resolution down to tenths of a microsecond, which is nice.  Until you learn that the resolution of the system clock is usually more coarse than several *milliseconds*, making the additional decimal places misleading garbage values. For calculating durations (time between events), it is better to use a high-resolution and monotonic clock like that provided by System.Diagnostics.Stopwatch: on most computers it is far more **accurate** than DateTime.Now even though, seemingly paradoxically, on a few systems, its *resolution* is lower than that of DateTime.  Also, unsurprisingly, Stopwatch does not provide values that correlate to times of day: while it is appropriate for calculating durations, it is inappropriate for timestamping against a readable date and time.  
@@ -17,6 +17,14 @@ With the "O" specifier, you can resolution down to tenths of a microsecond, whic
 This library provides timestamps (both as DateTime and as analogous value types it defines) that use the Stopwatch (and your system's high peformance event counter) as its clock, but returns values as DateTimes or an analog thereto so that these values can be used for a mixed purpose of timestamping and providing a meaningful way to calculate time elapsed between events or to calculate how long to perform a programmatic task.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReleaseNotes>
+      #### Version 1.0.0.4:
+      This release fixes two bugs.
+
+      First (see [Issue 21][8]), it fixes a bug where using monotonic timestamps close to the extreme values (within a month or so of 1-1-0001AD and 12-31-9999AD) was causing overflow in .NET 5.0.  The fix increased the buffer around the min/max values so that overflow does not occur in .NET 5.0.  You may have to alter your uses if you were (for some reason) storing portable monotonic stamps close to the extrema of permissible values.
+
+      Second (see [Issue 22][9]), it fixes a bug where subtracting a portable duration from a portable monotonic stamp was executing addition, not subtraction.  
+
+      Finally, please note that unit test applications, example code and test application are now all built and run against .NET 5.0 rather than .NET Core 3.1.
       #### Version 1.0.0.2:
       This release fixes a bug (see [Issue 19][1]) where the PortableDuration type's FromDays factory methods (and perhaps other From factory methods taking a double as a parameter) used incorrect math and incorrect validation logic.
 
@@ -33,12 +41,14 @@ This library provides timestamps (both as DateTime and as analogous value types 
       [5]: https://github.com/cpsusie/High-Precision-Time-Stamps/pull/14
       [6]: https://github.com/cpsusie/High-Precision-Time-Stamps/commit/01670d88755a4775100f7dd9d09eef61e0775555
       [7]: https://github.com/cpsusie/High-Precision-Time-Stamps/blob/01670d88755a4775100f7dd9d09eef61e0775555/PortableMonotonicStamp.cs#L540
+      [8]: https://github.com/cpsusie/High-Precision-Time-Stamps/issues/21
+      [9]: https://github.com/cpsusie/High-Precision-Time-Stamps/issues/22  
     </PackageReleaseNotes>
     <RepositoryUrl>https://github.com/cpsusie/High-Precision-Time-Stamps.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Timestamps DateTime Duration Monotonic-Clock TimeSpan High-Resolution ISO-8601</PackageTags>
-    <AssemblyVersion>1.0.0.2</AssemblyVersion>
-    <FileVersion>1.0.0.2</FileVersion>
+    <AssemblyVersion>1.0.0.4</AssemblyVersion>
+    <FileVersion>1.0.0.4</FileVersion>
     <Copyright>Copyright (c) 2020-2021 CJM Screws, LLC</Copyright>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/MonotonicTimeStamp.cs
+++ b/MonotonicTimeStamp.cs
@@ -179,9 +179,9 @@ namespace HpTimeStamps
         {
             long dateTimeUtcReferenceTicks = UtcReference.Ticks;
 
-
-            DateTime effectiveMinMonotonicDateTime = DateTime.MinValue.ToUniversalTime() + TimeSpan.FromDays(7);
-            DateTime effectiveMaxMonotonicDateTime = DateTime.MaxValue.ToUniversalTime() - TimeSpan.FromDays(7);
+            //bug issue 21 fix (7 day buffer -> 30 day buffer for .NET 5.0
+            DateTime effectiveMinMonotonicDateTime = DateTime.MinValue.ToUniversalTime() + TimeSpan.FromDays(30);
+            DateTime effectiveMaxMonotonicDateTime = DateTime.MaxValue.ToUniversalTime() - TimeSpan.FromDays(30);
             //Because MIN AND MAX are apparently UNSPECIFIED rather than UTC in some versions of .NET, it can screw up min max calculations.  Since we aren't likely to ever being collecting
             //monotonic stamps anywhere around min or max value, put a week buffer time in there to prevent conflict.
             long dateTimeMaxTimeSpanTicks = effectiveMaxMonotonicDateTime.Ticks;

--- a/PortableMonotonicStamp.cs
+++ b/PortableMonotonicStamp.cs
@@ -414,7 +414,8 @@ namespace HpTimeStamps
         /// <exception cref="PortableTimestampOverflowException">Caused overflow</exception>
         public static PortableMonotonicStamp operator -(in PortableMonotonicStamp minuend, in PortableDuration subtrahend)
         {
-            Int128 sum = minuend._dateTimeNanosecondOffsetFromMinValueUtc + subtrahend._ticks;
+            //issue 22 bug fix (+ -> -)
+            Int128 sum = minuend._dateTimeNanosecondOffsetFromMinValueUtc - subtrahend._ticks;
             if (sum >= MinValueUtcDtNanoseconds && sum <= MaxValueUtcDtNanoseconds)
             {
                 return new PortableMonotonicStamp(in sum);

--- a/Readme.md
+++ b/Readme.md
@@ -459,19 +459,30 @@ I have used this library to good effect in many projects, even closed-source pro
 4. An Amazon WorkSpaces Window Server (Windows 10 based Windows server) with (most vexingly) a stopwatch frequency of 2,441,366 ticks per second.  
 
 ### Release Notes
-#### Version 1.0.0.2:
+#### Version 1.0.0.4:  
+This release fixes two bugs.  
+
+First (see [Issue 21][8]), it fixes a bug where using monotonic timestamps close to the extreme values (within a month or so of 1-1-0001AD and 12-31-9999AD) was causing overflow in .NET 5.0.  The fix increased the buffer around the min/max values so that overflow does not occur in .NET 5.0.  You may have to alter your uses if you were (for some reason) storing portable monotonic stamps close to the extremes of permissible values.  
+  
+Second (see [Issue 22][9]), it fixes a bug where subtracting a portable duration from a portable monotonic stamp was executing addition, not subtraction.  
+  
+Finally, please note that unit test applications, example code and test application are now all built and run against .NET 5.0 rather than .NET Core 3.1.  
+  
+#### Version 1.0.0.2:  
 This release fixes a bug (see [Issue 19][1]) where the PortableDuration type's FromDays factory methods (and perhaps other From factory methods taking a double as a parameter) used incorrect math and incorrect validation logic.  
+  
+#### Version 1.0.0.1:  
+This release contains no changes to the code itself or to program behavior.  Instead it merely fixes the repository url to refer to the source repository rather than the http page that hosts the Github repository.  Also, it enables the nuget package to be built deterministically.  
+  
+#### Version 1.0.0.0:  
+This is the non-beta release of the fix introduced with beta version 0.1.1.0-beta.  The issues resolved by that release included problems with serialization and deserialization of portable monotonic stamps when serialized on a system with a different DateTime.MinValue.ToUniversalTime() value than the one on which it is deserialized.  Those changes are discussed in [pull request 14][2], [issue 12][3] and [issue 13][4].  The changes to the code can be reviewed in [pull request 14][2], [commit x][6] and, most particularly around [these lines of code][7].  
 
-#### Version 1.0.0.1:
-This release contains no changes to the code itself or to program behavior.  Instead it merely fixes the repository url to refer to the source repository rather than the http page that hosts the Github repository.  Also, it enables the nuget package to be built deterministically.
-
-#### Version 1.0.0.0:
-This is the non-beta release of the fix introduced with beta version 0.1.1.0-beta.  The issues resolved by that release included problems with serialization and deserialization of portable monotonic stamps when serialized on a system with a different DateTime.MinValue.ToUniversalTime() value than the one on which it is deserialized.  Those changes are discussed in [pull request 14][2], [issue 12][3] and [issue 13][4].  The changes to the code can be reviewed in [pull request 14][2], [commit x][6] and, most particularly around [these lines of code][7].
-
-  [1]: https://github.com/cpsusie/High-Precision-Time-Stamps/issues/19
-  [2]: https://github.com/cpsusie/High-Precision-Time-Stamps/pull/14
-  [3]: https://github.com/cpsusie/High-Precision-Time-Stamps/issues/12
-  [4]: https://github.com/cpsusie/High-Precision-Time-Stamps/issues/13
-  [5]: https://github.com/cpsusie/High-Precision-Time-Stamps/pull/14
-  [6]: https://github.com/cpsusie/High-Precision-Time-Stamps/commit/01670d88755a4775100f7dd9d09eef61e0775555
-  [7]: https://github.com/cpsusie/High-Precision-Time-Stamps/blob/01670d88755a4775100f7dd9d09eef61e0775555/PortableMonotonicStamp.cs#L540
+   [1]: https://github.com/cpsusie/High-Precision-Time-Stamps/issues/19  
+   [2]: https://github.com/cpsusie/High-Precision-Time-Stamps/pull/14  
+   [3]: https://github.com/cpsusie/High-Precision-Time-Stamps/issues/12  
+   [4]: https://github.com/cpsusie/High-Precision-Time-Stamps/issues/13  
+   [5]: https://github.com/cpsusie/High-Precision-Time-Stamps/pull/14  
+   [6]: https://github.com/cpsusie/High-Precision-Time-Stamps/commit/01670d88755a4775100f7dd9d09eef61e0775555  
+   [7]: https://github.com/cpsusie/High-Precision-Time-Stamps/blob/01670d88755a4775100f7dd9d09eef61e0775555/PortableMonotonicStamp.cs#L540  
+   [8]: https://github.com/cpsusie/High-Precision-Time-Stamps/issues/21  
+   [9]: https://github.com/cpsusie/High-Precision-Time-Stamps/issues/22

--- a/Release.txt
+++ b/Release.txt
@@ -1,16 +1,28 @@
-﻿#### Version 1.0.0.2:
+﻿#### Version 1.0.0.4:  
+This release fixes two bugs.  
+
+First (see [Issue 21][8]), it fixes a bug where using monotonic timestamps close to the extreme values (within a month or so of 1-1-0001AD and 12-31-9999AD) was causing overflow in .NET 5.0.  The fix increased the buffer around the min/max values so that overflow does not occur in .NET 5.0.  You may have to alter your uses if you were (for some reason) storing portable monotonic stamps close to the extrema of permissible values.  
+  
+Second (see [Issue 22][9]), it fixes a bug where subtracting a portable duration from a portable monotonic stamp was executing addition, not subtraction.  
+  
+Finally, please note that unit test applications, example code and test application are now all built and run against .NET 5.0 rather than .NET Core 3.1.  
+  
+#### Version 1.0.0.2:  
 This release fixes a bug (see [Issue 19][1]) where the PortableDuration type's FromDays factory methods (and perhaps other From factory methods taking a double as a parameter) used incorrect math and incorrect validation logic.  
-
-#### Version 1.0.0.1:
-This release contains no changes to the code itself or to program behavior.  Instead it merely fixes the repository url to refer to the source repository rather than the http page that hosts the Github repository.  Also, it enables the nuget package to be built deterministically.
-
-#### Version 1.0.0.0:
-This is the non-beta release of the fix introduced with beta version 0.1.1.0-beta.  The issues resolved by that release included problems with serialization and deserialization of portable monotonic stamps when serialized on a system with a different DateTime.MinValue.ToUniversalTime() value than the one on which it is deserialized.  Those changes are discussed in [pull request 14][2], [issue 12][3] and [issue 13][4].  The changes to the code can be reviewed in [pull request 14][2], [commit x][6] and, most particularly around [these lines of code][7].
-
-  [1]: https://github.com/cpsusie/High-Precision-Time-Stamps/issues/19
-  [2]: https://github.com/cpsusie/High-Precision-Time-Stamps/pull/14
-  [3]: https://github.com/cpsusie/High-Precision-Time-Stamps/issues/12
-  [4]: https://github.com/cpsusie/High-Precision-Time-Stamps/issues/13
-  [5]: https://github.com/cpsusie/High-Precision-Time-Stamps/pull/14
-  [6]: https://github.com/cpsusie/High-Precision-Time-Stamps/commit/01670d88755a4775100f7dd9d09eef61e0775555
-  [7]: https://github.com/cpsusie/High-Precision-Time-Stamps/blob/01670d88755a4775100f7dd9d09eef61e0775555/PortableMonotonicStamp.cs#L540
+  
+#### Version 1.0.0.1:  
+This release contains no changes to the code itself or to program behavior.  Instead it merely fixes the repository url to refer to the source repository rather than the http page that hosts the Github repository.  Also, it enables the nuget package to be built deterministically.  
+  
+#### Version 1.0.0.0:  
+This is the non-beta release of the fix introduced with beta version 0.1.1.0-beta.  The issues resolved by that release included problems with serialization and deserialization of portable monotonic stamps when serialized on a system with a different DateTime.MinValue.ToUniversalTime() value than the one on which it is deserialized.  Those changes are discussed in [pull request 14][2], [issue 12][3] and [issue 13][4].  The changes to the code can be reviewed in [pull request 14][2], [commit x][6] and, most particularly around [these lines of code][7].  
+  
+  
+	[1]: https://github.com/cpsusie/High-Precision-Time-Stamps/issues/19  
+	[2]: https://github.com/cpsusie/High-Precision-Time-Stamps/pull/14  
+	[3]: https://github.com/cpsusie/High-Precision-Time-Stamps/issues/12  
+	[4]: https://github.com/cpsusie/High-Precision-Time-Stamps/issues/13  
+	[5]: https://github.com/cpsusie/High-Precision-Time-Stamps/pull/14  
+	[6]: https://github.com/cpsusie/High-Precision-Time-Stamps/commit/01670d88755a4775100f7dd9d09eef61e0775555  
+	[7]: https://github.com/cpsusie/High-Precision-Time-Stamps/blob/01670d88755a4775100f7dd9d09eef61e0775555/PortableMonotonicStamp.cs#L540  
+	[8]: https://github.com/cpsusie/High-Precision-Time-Stamps/issues/21  
+	[9]: https://github.com/cpsusie/High-Precision-Time-Stamps/issues/22  

--- a/TestApp/ConsoleApp1/TestApp.csproj
+++ b/TestApp/ConsoleApp1/TestApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/UnitTests/UnitTests/StampTests.cs
+++ b/UnitTests/UnitTests/StampTests.cs
@@ -177,6 +177,29 @@ namespace UnitTests
             Helper.WriteLine($"{nameof(localStampUpMicro)}:\t\t[{localStampUpMicro}].");
 
         }
+        /// <summary>
+        /// Bug 22 fix unit test
+        /// </summary>
+        [Fact]
+        public void TestPortableDurationArithmetic()
+        {
+            DateTime date = new DateTime(2069, 06, 10, 18, 42, 49, 333, DateTimeKind.Utc);
+            TimeSpan span = TimeSpan.FromDays(12.912);
+            TestOperation(date, span, (d, s) => d - s, (p, d) => p-d);
+        }
+
+        private void TestOperation(DateTime dateTime, TimeSpan ts, Func<DateTime, TimeSpan, DateTime> dtOp,
+            Func<PortableMonotonicStamp, PortableDuration, PortableMonotonicStamp> stampOp)
+        {
+            Assert.NotNull(dtOp);
+            Assert.NotNull(stampOp);
+            
+            PortableMonotonicStamp stamp = dateTime;
+            PortableDuration pd = ts;
+
+            Assert.True(dtOp(dateTime, ts) == stampOp(stamp, pd));
+        }
+
         [Fact]
         public void TestPortableStamp()
         {

--- a/UnitTests/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests/UnitTests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <LangVersion>8.0</LangVersion>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fix issue 21 by adjusting min max buffer period for portable stamp to 30 days.  7 was too short in .NET 5.0.  Fix issue 22 by changing '+' to '-' where in subtraction operator for a minuend of type portablemonotonicstamp and a subtrahend of portable duration.  Add unit test to prove fix.  Change all C# ancillary projects (unit test, example code, test app) to be built and run against .NET 5.0 rather than .NETCore 3.0.  Change version number to 1.0.0.4.  Update Readme.md; Update Release.txt.